### PR TITLE
Add readme for go github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,39 @@
 # Engage
+
 The purpose of this repository is to list the rules of engagement, how to submit to repositories and how a pull request flow should go.
 
 ## Repository Structure
+
 <Description Place Holder>
 <Link to dedicated MD file with info specific to this section>
 
 ## [General submission guidelines](https://github.com/k8-proxy/Engage/blob/main/Code-submission-guidelines.md)
+
 <Description Place Holder>
 <Link to dedicated MD file with info specific to this section>
 
 ### [Python](https://github.com/k8-proxy/Engage/blob/main/Python.md)
+
 <Description Place Holder>
 <Link to dedicated MD file with info specific to this section>
 
 ### [Golang](https://blog.golang.org/godoc)
+
+<Description Place Holder>
+<Link to dedicated MD file with info specific to this section>
+
+### [Go GitHub Actions](go-github-actions.md)
+
 <Description Place Holder>
 <Link to dedicated MD file with info specific to this section>
 
 ### [shell Scripts](https://github.com/k8-proxy/Engage/blob/main/Shell-guide.md)
+
 <Description Place Holder>
 <Link to dedicated MD file with info specific to this section>
 
-
 ## Recommended Tools
+
 <This section might move into the dedicated MD files>
 <Description Place Holder>
 <Link to dedicated MD file with info specific to this section>

--- a/go-codecov.md
+++ b/go-codecov.md
@@ -5,14 +5,24 @@
 - Sign in for [codecov](https://codecov.io/).
 - Choose Your repo.
 - Copy the token of that repo.
-  It's not required for public repo.
-- Open badge tab and copy the link.
+  - This step is not required for public repo.
 
 ## GitHub
 
-- In your README.md file put the link you obtained from the badge tab.
+- In your README.md file.
+
+  - Copy that link:
+
+  ```
+    <a href="https://codecov.io/gh/<your_github_user_name>/<your_repo>">
+        <img src="https://codecov.io/gh/<your_github_user_name>/<your_repo>/branch/main/graph/badge.svg"/>
+    </a>
+  ```
+
+  - Change the variables to suit you.
+
 - Open repo setting and add a secret which the key is CODECOV_TOKEN and the value is the token you obtained.
-  It's not required for public repo.
+  - This step is not required for public repo.
 
 ## Snapshot of the code
 

--- a/go-codecov.md
+++ b/go-codecov.md
@@ -5,7 +5,6 @@
 - Sign in for [codecov](https://codecov.io/).
 - Choose Your repo.
 - Copy the token of that repo.
-  - This step is not required for public repo.
 
 ## GitHub
 
@@ -22,7 +21,6 @@
   - Change the variables to suit you.
 
 - Open repo setting and add a secret which the key is CODECOV_TOKEN and the value is the token you obtained.
-  - This step is not required for public repo.
 
 ## Snapshot of the code
 
@@ -68,6 +66,8 @@ jobs:
           name: codecov-umbrella
 
 ```
+
+- Change the variable to suit you: <go_version>.
 
 ### To exclude directories that aren't required for test(ex. examples directory)
 

--- a/go-codecov.md
+++ b/go-codecov.md
@@ -5,14 +5,14 @@
 - Sign up for [codecov](https://codecov.io/).
 - Choose Your repo.
 - Copy the token of that repo.
-  It's not required for public repo.
+  <cite>It's not required for public repo.</cite>
 - Open badge tab and copy the link.
 
 ## GitHub
 
 - In your README.md file put the link you obtained from the badge tab.
 - Open repo setting and add a secret which the key is CODECOV_TOKEN and the value is the token you obtained.
-  It's not required for public repo.
+  <cite>It's not required for public repo.</cite>
 
 ## Snapshot of the code
 

--- a/go-codecov.md
+++ b/go-codecov.md
@@ -11,7 +11,7 @@
 
 - In your README.md file.
 
-  - Copy that link:
+  - Copy and add that link:
 
   ```
     <a href="https://codecov.io/gh/<your_github_user_name>/<your_repo>">

--- a/go-codecov.md
+++ b/go-codecov.md
@@ -2,17 +2,17 @@
 
 ## codecov
 
-- Sign up for [codecov](https://codecov.io/).
+- Sign in for [codecov](https://codecov.io/).
 - Choose Your repo.
 - Copy the token of that repo.
-  <cite>It's not required for public repo.</cite>
+  It's not required for public repo.
 - Open badge tab and copy the link.
 
 ## GitHub
 
 - In your README.md file put the link you obtained from the badge tab.
 - Open repo setting and add a secret which the key is CODECOV_TOKEN and the value is the token you obtained.
-  <cite>It's not required for public repo.</cite>
+  It's not required for public repo.
 
 ## Snapshot of the code
 

--- a/go-codecov.md
+++ b/go-codecov.md
@@ -1,0 +1,73 @@
+# Go codecov
+
+## codecov
+
+- Sign up for [codecov](https://codecov.io/).
+- Choose Your repo.
+- Copy the token of that repo.
+  It's not required for public repo.
+- Open badge tab and copy the link.
+
+## GitHub
+
+- In your README.md file put the link you obtained from the badge tab.
+- Open repo setting and add a secret which the key is CODECOV_TOKEN and the value is the token you obtained.
+  It's not required for public repo.
+
+## Snapshot of the code
+
+### in yaml file
+
+- Located in .github/workflow directory
+
+```
+name: codecov
+on: [push]
+jobs:
+  codecov:
+    name: codecov
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go <go_version>
+        uses: actions/setup-go@v1
+        with:
+          go-version: <go_version>
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+          if [ -f Gopkg.toml ]; then
+              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+              dep ensure
+          fi
+
+      - name: Generate coverage report
+        run: |
+          go test `go list ./...`  -coverprofile=coverage.txt -covermode=atomic
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v1.0.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.txt
+          flags: unittests
+          name: codecov-umbrella
+
+```
+
+### To exclude directories that aren't required for test(ex. examples directory)
+
+```
+      - name: Generate coverage report
+        run: |
+          go test `go list ./... | grep -v examples`  -coverprofile=coverage.txt -covermode=atomic
+
+```
+
+## Reference
+
+[CODECOV](https://github.com/marketplace/actions/codecov)

--- a/go-github-actions.md
+++ b/go-github-actions.md
@@ -1,0 +1,14 @@
+# Go GitHub Actions
+
+## Create GitHub Action
+
+- In your repo choose the actions tab.
+- Select the Go option.
+- That will create a directory ./.github/workflow
+- You can create your yaml file in here and it will be considered an action.
+
+## Example
+
+### codecov
+
+To get start with codecov, please check [go codecov](go-codecov.md)

--- a/go-github-actions.md
+++ b/go-github-actions.md
@@ -5,10 +5,10 @@
 - In your repo choose the actions tab.
 - Select the Go option.
 - That will create a directory ./.github/workflow
-- You can create your yaml file in here and it will be considered an action.
+- You can create your yaml file in here and it will be considered as an action.
 
-## Example
+## Examples
 
 ### codecov
 
-To get start with codecov, please check [go codecov](go-codecov.md)
+- To add code coverage for your Go project, please check [go codecov](go-codecov.md)


### PR DESCRIPTION
Fixes #17 
Add GitHub Actions with codecov as an example with the steps required.